### PR TITLE
CO-1608: Updates filter parameter styles to add noneOf/hasNone filters and disambiguate existing styles

### DIFF
--- a/OpenAPI.md
+++ b/OpenAPI.md
@@ -17,15 +17,17 @@ corresponds to an `attribute` of the resource, it should be named after this att
 Below is a list of allowed values for `operation`
 
 | `operation` | Description                                    |
-|-------------|------------------------------------------------|
+| ----------- | ---------------------------------------------- |
 | `neq`       | Not equal to                                   |
 | `gt`        | Greater than                                   |
 | `gte`       | Greater than or equal to                       |
 | `lt`        | Less than                                      |
 | `lte`       | Less than or equal to                          |
 | `oneOf`     | `field` is one of the following                |
-| `some`      | `field` contains at least one of the following |
-| `all`       | `field` contains at least all of the following |
+| `noneOf`    | `field` is none of the following               |
+| `hasSome`   | `field` contains at least one of the following |
+| `hasAll`    | `field` contains all of the following          |
+| `hasNone`   | `field` contains none of the following         |
 | `fuzzy`     | `value` partially matches `field`              |
 
 ### Examples


### PR DESCRIPTION
This update style guidelines so that filters referring to single item fields are always postfixed with `-Of` and filters for multi-item fields are always prefixed with `has-`. It also adds `noneOf` and `hasNone` as new options for filters.